### PR TITLE
Use single line syntax in metadata

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -30,9 +30,7 @@ authors:
     orcid: 0000-0002-4494-5124
     affiliation: 1
 affiliations:
-  - name: | 
-      European Molecular Biology Laboratory, European Bioinformatics Institute (EMBL-EBI), 
-      Wellcome Trust Genome Campus, Hinxton, Cambridge CB10 1SD, UK
+  - name: European Molecular Biology Laboratory, European Bioinformatics Institute (EMBL-EBI), Wellcome Trust Genome Campus, Hinxton, Cambridge CB10 1SD, UK
     index: 1
 date: 26 September 2024
 bibliography: paper.bib


### PR DESCRIPTION
This PR should fix the [error](https://github.com/openjournals/joss-reviews/issues/7604#issuecomment-2654695336) in the generated metadata files for the JOSS paper.